### PR TITLE
Remove t from the list of required AS tags

### DIFF
--- a/libopenarc/arc.c
+++ b/libopenarc/arc.c
@@ -1670,8 +1670,7 @@ arc_process_set(ARC_MESSAGE *msg, arc_kvsettype_t type, u_char *str,
 		    arc_param_get(set, (u_char *) "b") == NULL ||
 		    arc_param_get(set, (u_char *) "s") == NULL ||
 		    arc_param_get(set, (u_char *) "d") == NULL ||
-		    arc_param_get(set, (u_char *) "a") == NULL ||
-		    arc_param_get(set, (u_char *) "t") == NULL)
+		    arc_param_get(set, (u_char *) "a") == NULL)
 		{
 			arc_error(msg, "missing parameter(s) in %s data",
 			          settype);


### PR DESCRIPTION
"t" is imported from RFC 6376 section 3.5, which states:

    t= Signature Timestamp (plain-text unsigned decimal integer;
       RECOMMENDED, default is an unknown creation time).  The time
       that this signature was created.

Its inclusion in this list results in spurious ARC verification
failures.